### PR TITLE
Fixed FEAT command to be in line with rfc2389

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/.idea

--- a/src/server.rs
+++ b/src/server.rs
@@ -861,7 +861,8 @@ where
                         }
                         Command::Feat => {
                             ensure_authenticated!();
-                            let response = "211 I support some cool features\r\n\
+                            let response = "211-Extensions supported:\r\n \
+                                            I support some cool features\r\n\
                                             211 End\r\n"
                                 .to_string();
                             Ok(response)


### PR DESCRIPTION
The FEAT command did not parse correctly with an FTP client.